### PR TITLE
Update team.de.md

### DIFF
--- a/team.de.md
+++ b/team.de.md
@@ -11,8 +11,8 @@ permalink: /team.html
 
 ## Arbeitsstelle Dresden
 - [Dr. Andrea Hartmann](team/dr-andrea-hartmann.html "Opens internal link in current window") (Leitung)
-- [Dr. Miriam Roner](team/dr-miriam-roner.html "Opens window for sending email")
-- [Dr. Undine Wagner](team/dr-undine-wagner.de.md "Opens internal link in current window")
+- [Dr. Miriam Roner](team/dr-miriam-roner.html "Opens internal link in current window")
+- [Dr. Undine Wagner](team/dr-undine-wagner.html "Opens internal link in current window")
 
 ## Arbeitsstelle München
 - [Dr. Gottfried Heinz-Kronberger](team/dr-gottfried-heinz-kronberger.html "Opens internal link in current window") (Leitung)


### PR DESCRIPTION
Verlinkung: auf https://de.rism.info/de/team.html bei Wagner führt der Link ins Leere.