### PR TITLE
Clean up Rothenburg Stadtarchiv description

### DIFF
--- a/musicmanuscripts/liste-aller-fundorte/rothenburg.de.md
+++ b/musicmanuscripts/liste-aller-fundorte/rothenburg.de.md
@@ -8,6 +8,4 @@ permalink: '/musicmanuscripts/liste-aller-fundorte/rothenburg.html'
 
 # Rothenburg ob der Tauber, Stadtarchiv (D-RB)
 
-Im Stadtarchiv sind Teile eines Kantatenjahrgangs von Franz Vollrath Buttstett (1735-1814) erhalten. Daneben bewahrt das Archiv wenige Handschriften und Drucke des 19. und 20. Jahrhunderts auf. 
-
-• Zuständig: RISM-Arbeitsstelle München.
+Im Stadtarchiv sind Teile eines Kantatenjahrgangs von Franz Vollrath Buttstett (1735-1814) erhalten. Daneben bewahrt das Archiv wenige Handschriften und Drucke des 19. und 20. Jahrhunderts auf.


### PR DESCRIPTION
Removed unnecessary bullet point about RISM-Arbeitsstelle München.