### PR TITLE
Revise Stuttgart music manuscripts details

### DIFF
--- a/musicmanuscripts/liste-aller-fundorte/stuttgart.de.md
+++ b/musicmanuscripts/liste-aller-fundorte/stuttgart.de.md
@@ -9,7 +9,8 @@ permalink: '/musicmanuscripts/liste-aller-fundorte/stuttgart.html'
 
 # Stuttgart, Württembergische Landesbibliothek (D-Sl)
 
-Die Stuttgarter Musikhandschriften wurden nicht von RISM, sondern im Rahmen von DFG-Projekten katalogisiert und sind daher nicht im RISM OPAC nachgewiesen. Es liegen gedruckte Kataloge von Clytus Gottwald vor.
+Die Stuttgarter Musikhandschriften sind in 3 Gruppen unterteilt, die Handschriften "erster Reihen" (Codices musici I) und "zweiter Reihe" (Codices musici II) sowie die Musikbestände der ehemaligen königlichen Hofbibliothek. Die Handschriften der ersten Reihe und die Handschriften der Hofbibliothek wurden nicht von RISM, sondern im Rahmen von DFG-Projekten katalogisiert und sind daher bisher nicht im RISM OPAC nachgewiesen. Es liegen gedruckte Kataloge von Clytus Gottwald vor.
+Die Musikhandschriften der zweiten Reihe, die vor allem musikalische Erwerbungen (Noten) der Württembergischen Landesbibliothek sowie Stiftungen und Nachlässe württembergischer Komponisten und Komponistinnen umfasst, sind seit 2026 vollständig im RISM-OPAC nachgewiesen. 
 
 Weitere Informationen auf der Website der Bibliothek: [Württembergische Landesbibliothek](https://www.wlb-stuttgart.de/sammlungen/musik/bestand/musik-und-musikerhandschriften/ "Opens external link in new window"){:blank}.
 
@@ -27,5 +28,8 @@ Clytus Gottwald: _HB XVII 29-480. Die Handschriften der Württembergischen Lande
 
 Clytus Gottwald: _HB XVII 481-946. Die Handschriften der Württembergischen Landesbibliothek, II. Reihe, 6. Band, Teil 3. Die Handschriften der ehemaligen Königlichen Hofbibliothek. Codices musici_, Wiesbaden 2004.
 
+Helmut Lauterwasser: _Katalog der „Musikhandschriften Der Zweiten Reihe“ in der Württembergischen Landesbibliothek: Thematischer Katalog._, Frankfurt/München 2026 online verfügbar (abgerufen am 16.06.2026): regiopen.books. https://doi.org/10.53458/ttz7gg03
+
 (Armin Brinzing, April 2011)
+(Update: Steffen Voss, Juni 2026)
 


### PR DESCRIPTION
Updated the description of the Stuttgart music manuscripts, detailing their categorization and cataloging status in RISM OPAC.